### PR TITLE
Fix minor issues I found

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ hotpot serve
 ### Docker
 ```bash
 # Either pull the pre-built container from GitHub Container Registry
-docker pull ghcr.io/erik/hotpot:latest
+docker pull ghcr.io/erik/hotpot:main
 
 # Or build the Docker image yourself
 docker build -t hotpot .

--- a/src/strava.rs
+++ b/src/strava.rs
@@ -343,8 +343,8 @@ Next, make sure the webhook is set up to be called for new activities:
 Confirm the webhook was set up correctly with:
 
     curl --get https://www.strava.com/api/v3/push_subscriptions \\
-         -F \"client_id={0}\" \\
-         -F \"client_secret={1}\"
+         -d \"client_id={0}\" \\
+         -d \"client_secret={1}\"
 
 More information: https://developers.strava.com/docs/getting-started
 ",


### PR DESCRIPTION
The docker container with the `latest` tag doesn't exist, there's only `main`, so I updated that in the readme.

Changed the command to verify a strava webhook to use urlencoded instead of multipart/form-data, according to the [strava API docs](https://developers.strava.com/docs/webhooks/#view-a-subscription). It didn't work with multipart for me.